### PR TITLE
Added easy debugging via "make debug" and VSCode launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+    "version": "0.2.0",
+    // run "make debug" in a terminal, then "Run and Debug" in VSCode
+    "configurations": [
+        {
+            // debug the kernel
+            "name": "debug kernel",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/kernel/bin/kernel",
+            "cwd": "${workspaceRoot}",
+            "miDebuggerPath": "gdb",
+            "miDebuggerServerAddress": "127.0.0.1:26000",
+            "MIMode": "gdb",
+            "stopAtEntry": false,
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": false
+                }
+            ]
+        }
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ include tools/utils.mk
 
 $(call USER_VARIABLE, KARCH, x86_64)
 $(call USER_VARIABLE, QEMUFLAGS, -m 128M -M smm=off -serial stdio -d int -D qemu.log -no-reboot -no-shutdown)
+$(call USER_VARIABLE, QEMU_DEBUG_FLAGS, -S -gdb tcp:localhost:26000)
 
 override OUTPUT := zeronix.iso
 
@@ -44,6 +45,14 @@ run: ovmf disk
 		-drive if=pflash,unit=1,format=raw,file=ovmf/ovmf-vars-$(KARCH).fd \
 		-cdrom $(OUTPUT) \
 		$(QEMUFLAGS)
+
+debug: ovmf disk
+	qemu-system-$(KARCH) \
+		-M q35 \
+		-drive if=pflash,unit=0,format=raw,file=ovmf/ovmf-code-$(KARCH).fd,readonly=on \
+		-drive if=pflash,unit=1,format=raw,file=ovmf/ovmf-vars-$(KARCH).fd \
+		-cdrom $(OUTPUT) \
+		$(QEMUFLAGS) $(QEMU_DEBUG_FLAGS)
 
 menuconfig:
 	kconfig-mconf Kconfig

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ You can run Zeronix in QEMU by running:
 make run
 ```
 
+For debugging, run
+
+```sh
+make debug
+```
+
+and attach gdb on localhost, port 26000. To debug from VSCode a preset exists in `launch.json`.
+
 ### Real Hardware
 
 You can run Zeronix on real hardware by using [Balena Etcher] to flash the ISO

--- a/kernel/src/util/kprintf.c
+++ b/kernel/src/util/kprintf.c
@@ -28,7 +28,7 @@ int kprintf(const char *fmt, ...)
     char buf[1024];
     va_list args;
 
-    va_start(args, format);
+    va_start(args, fmt);
     int len = npf_vsnprintf(buf, sizeof(buf), fmt, args);
     va_end(args);
 


### PR DESCRIPTION
Based on your reddit question, this is how you can use VSCode for debugging.
Set a breakpoint, call "make debug" and start gdb via VSCode (the setting "debug kernel" is in the launch.json).
(Also fixed variable name in kprintf)